### PR TITLE
feat: karaoke defaulting to regular

### DIFF
--- a/syncedlyrics/providers/musixmatch.py
+++ b/syncedlyrics/providers/musixmatch.py
@@ -123,4 +123,7 @@ class Musixmatch(LRCProvider):
         if not track:
             return None
         track_id = track["track"]["track_id"]
-        return (self.enhanced and self.get_lrc_word_by_word(track_id)) or self.get_lrc_by_id(track_id)
+        if self.enhanced:
+            return self.get_lrc_word_by_word(track_id) or self.get_lrc_by_id(track_id)
+        else:
+            return self.get_lrc_by_id(track_id)

--- a/syncedlyrics/providers/musixmatch.py
+++ b/syncedlyrics/providers/musixmatch.py
@@ -123,6 +123,4 @@ class Musixmatch(LRCProvider):
         if not track:
             return None
         track_id = track["track"]["track_id"]
-        if self.enhanced:
-            return self.get_lrc_word_by_word(track_id)
-        return self.get_lrc_by_id(track_id)
+        return (self.enhanced and self.get_lrc_word_by_word(track_id)) or self.get_lrc_by_id(track_id)


### PR DESCRIPTION
I noticed that when requesting enhanced lyrics, if none are available, another call is needed. This PR makes it so that if no enhanced lyrics are available, it defaults to normal lyrics by id.