### PR TITLE
Use best match instead of first synced lyrics

### DIFF
--- a/syncedlyrics/providers/lrclib.py
+++ b/syncedlyrics/providers/lrclib.py
@@ -35,13 +35,13 @@ class Lrclib(LRCProvider):
         tracks = sort_results(
             tracks, search_term, lambda t: f'{t["artistName"]} - {t["trackName"]}'
         )
-        # _id = str(tracks[0]["id"])
+        _id = str(tracks[0]["id"])
         # Getting the first track that its `syncedLyrics` is not empty
-        _id = None
-        for track in tracks:
-            if (track.get("syncedLyrics", "") or "").strip():
-                _id = str(track["id"])
-                break
-        if not _id:
-            return None
+        # _id = None
+        # for track in tracks:
+        #     if (track.get("syncedLyrics", "") or "").strip():
+        #         _id = str(track["id"])
+        #         break
+        # if not _id:
+        #     return None
         return self.get_lrc_by_id(_id)


### PR DESCRIPTION
This would fix #46 , I still don't see why it should use the first track with synced lyrics instead of the best match, so this change seems obvious, but maybe there was a reason for this I'm missing?
For me at least I'd rather have no lyrics than wrong ones, especially since there are still other providers that can be searched afterwards.